### PR TITLE
Move the inline js into content-stats.js.

### DIFF
--- a/ftw/contentstats/browser/resources/content-stats.js
+++ b/ftw/contentstats/browser/resources/content-stats.js
@@ -1,0 +1,83 @@
+
+function bindeTableHoverEffects(name, chart) {
+  var selector = '#content-stats-type-counts-' + name + ' tr';
+  $(selector).on('mouseover', function(event) {
+    chart.focus(event.currentTarget.dataset.id);
+  });
+
+  $(selector).on('mouseout', function(event) {
+    chart.focus();
+  });
+
+  $(selector).each(function( index ) {
+      var data_id = this.dataset.id;
+      d3.select(this).selectAll('td .legend-color')
+                     .style('background-color', chart.color(data_id));
+  });
+}
+
+function createPieChart(name, data) {
+  var pie_chart = c3.generate({
+    bindto: '#pie-chart-' + name,
+    data: {
+        json: [data],
+        type : 'pie',
+        legend: false,
+        keys: {'value': Object.keys(data)},
+    },
+    size: {
+        height: 360,
+        width: 480
+    },
+    tooltip: {
+        format: {
+            value: function (value, ratio, id) {return value;}
+        }
+    }
+  });
+
+  pie_chart.legend.hide();
+  bindeTableHoverEffects(name, pie_chart);
+}
+
+function createBarChart(name, data) {
+  var bar_chart = c3.generate({
+    bindto: '#bar-chart-' + name,
+    data: {
+        json: [data],
+        type : 'bar',
+        labels: true,
+        legend: false,
+        keys: {'value': Object.keys(data)}
+    },
+    tooltip: {
+        grouped: false // Default true
+    },
+    axis: {
+        x: {show:false}
+    },
+    grid: {
+        y: {
+            show: true
+        }
+    }
+  });
+
+  bar_chart.legend.hide();
+  bindeTableHoverEffects(name, bar_chart);
+}
+
+
+$(function() {
+
+  $('.statistic-wrapper').each(function(){
+    var wrapper = $(this);
+    var infos = wrapper.find('.content-stats-infos');
+    var data = infos.data('counts');
+    var name = infos.data('name');
+
+    createPieChart(name, data);
+    createBarChart(name, data);
+  });
+
+});

--- a/ftw/contentstats/browser/templates/content_stats.pt
+++ b/ftw/contentstats/browser/templates/content_stats.pt
@@ -9,6 +9,7 @@
         <link href="/++resource++ftw.contentstats/content-stats.css" rel="stylesheet" type="text/css">
         <script src="/++resource++ftw.contentstats/d3.v3.min.js" charset="utf-8"></script>
         <script src="/++resource++ftw.contentstats/c3.min.js"></script>
+        <script src="/++resource++ftw.contentstats/content-stats.js"></script>
     </metal:head>
 
     <metal:block fill-slot="top_slot"
@@ -31,101 +32,30 @@
                                        json python: view.jsonify(data);">
 
                 <div tal:attributes="id string:content-stats-data-${name};
-                                     data-counts json">
+                                     data-counts json;
+                                     data-name name"
+                     class="content-stats-infos">
 
                     <h2 tal:content="title" />
 
-                    <script tal:content="string:var statisticName = '${name}'" />
-
-                    <script type="text/javascript">
-                        var counts = $('#content-stats-data-'+ statisticName + '').data('counts')
-                        var titles = Object.keys(counts);
-                    </script>
-
                     <table tal:attributes="id string:content-stats-type-counts-${name}">
                         <tr tal:repeat="type_count python:sorted(data.items())" tal:attributes="data-id python:type_count[0]">
-                        <td><span class="legend-color"/></td>
-                        <td tal:content="python:type_count[0]">portal_type</td>
-                        <td tal:content="python:type_count[1]">count</td>
-                    </tr>
-                </table>
+                            <td><span class="legend-color"/></td>
+                            <td tal:content="python:type_count[0]">portal_type</td>
+                            <td tal:content="python:type_count[1]">count</td>
+                        </tr>
+                    </table>
 
 
                     <!-- Pie Chart -->
                     <div tal:attributes="id string:pie-chart-${name}"></div>
-                    <script type="text/javascript">
-                        var pie_chart = c3.generate({
-                            bindto: '#pie-chart-' + statisticName,
-                            data: {
-                                json: [counts],
-                                type : 'pie',
-                                legend: false,
-                                keys: {'value': titles},
-                            },
-                            size: {
-                                height: 360,
-                                width: 480
-                            },
-                            tooltip: {
-                                format: {
-                                    value: function (value, ratio, id) {return value}
-                                }
-                            }
-                        });
-                        pie_chart.legend.hide();
-                    </script>
 
                     <div style="clear:both"><!-- --></div>
                     <br/><br/>
 
                     <!-- Bar Chart -->
                     <div tal:attributes="id string:bar-chart-${name}"></div>
-                    <script type="text/javascript">
-                        var bar_chart = c3.generate({
-                            bindto: '#bar-chart-' + statisticName,
-                            data: {
-                                json: [counts],
-                                type : 'bar',
-                                labels: true,
-                                legend: false,
-                                keys: {'value': titles}
-                            },
-                            tooltip: {
-                                grouped: false // Default true
-                            },
-                            axis: {
-                                x: {show:false}
-                            },
-                            grid: {
-                                y: {
-                                    show: true
-                                }
-                            }
-                        });
-                        bar_chart.legend.hide();
 
-                    </script>
-
-                    <script type="text/javascript">
-                        $("#content-stats-type-counts-" + statisticName + " tr")
-                            .on("mouseover", (event) => {
-                                pie_chart.focus(event.currentTarget.dataset.id);
-                                bar_chart.focus(event.currentTarget.dataset.id)
-                        });
-
-                        $("#content-stats-type-counts-" + statisticName + " tr")
-                            .on("mouseout", (event) => {
-                                pie_chart.focus();
-                                bar_chart.focus()
-                        });
-
-                        $("#content-stats-type-counts-" + statisticName + " tr")
-                            .each(function( index ) {
-                                var data_id = this.dataset.id;
-                                d3.select(this).selectAll('td .legend-color')
-                                    .style('background-color', pie_chart.color(data_id)
-                        )});
-                    </script>
                 </div>
             </tal:statistic>
         </div>


### PR DESCRIPTION
This PR bases on #4 

I moved the inline js into the content-stats.js.
It's overall much more readable this way and it also fixes the scope mess. 

![stats2](https://user-images.githubusercontent.com/437933/29701833-818c20d2-896e-11e7-9ed0-74614420294b.gif)
