### PR TITLE
Fail gracefully if eventlog config can't be found

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,8 @@ log will be named ``contentstats-json.log``.
 **Note**: In order to figure out the appropriate log directory,
 ``ftw.contentstats`` needs to derive this information from the eventlog
 location. It's therefore important to have an eventlog configured, otherwise
-``ftw.contentstats`` will prevent instance startup.
+``ftw.contentstats`` will not be able to log any content stats, and complain
+noisily through the root logger.
 
 
 Development

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fail gracefully if eventlog config can't be found in order to derive
+  log location from it. Instead of potentially preventing instance startup,
+  log a noticeable error message using the root logger.
+  [lgraf]
 
 
 1.0.0 (2017-09-03)


### PR DESCRIPTION
Fail gracefully if eventlog config can't be found in order to derive log location from it. Instead of potentially preventing instance startup, log a noticeable error message using the root logger.