### PR TITLE
Properly build ++resource++ URLs by prefixing them with portal_url

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Properly build ++resource++ URLs by prefixing them with portal_url instead
+  of just a slash. [lgraf]
 
 
 1.0.1 (2017-09-04)

--- a/ftw/contentstats/browser/templates/content_stats.pt
+++ b/ftw/contentstats/browser/templates/content_stats.pt
@@ -4,12 +4,13 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       metal:use-macro="context/main_template/macros/master">
 
-    <metal:head fill-slot="head_slot">
-        <link href="/++resource++ftw.contentstats/c3.min.css" rel="stylesheet" type="text/css" />
-        <link href="/++resource++ftw.contentstats/content-stats.css" rel="stylesheet" type="text/css" />
-        <script src="/++resource++ftw.contentstats/d3.v3.min.js" charset="utf-8"></script>
-        <script src="/++resource++ftw.contentstats/c3.min.js"></script>
-        <script src="/++resource++ftw.contentstats/content-stats.js"></script>
+    <metal:head fill-slot="head_slot"
+                tal:define="portal_url context/@@plone_portal_state/portal_url">
+        <link href="${portal_url}/++resource++ftw.contentstats/c3.min.css" rel="stylesheet" type="text/css" />
+        <link href="${portal_url}/++resource++ftw.contentstats/content-stats.css" rel="stylesheet" type="text/css" />
+        <script src="${portal_url}/++resource++ftw.contentstats/d3.v3.min.js" charset="utf-8"></script>
+        <script src="${portal_url}/++resource++ftw.contentstats/c3.min.js"></script>
+        <script src="${portal_url}/++resource++ftw.contentstats/content-stats.js"></script>
     </metal:head>
 
     <metal:block fill-slot="top_slot"


### PR DESCRIPTION
Properly build `++resource++` URLs by prefixing them with portal_url instead of just a slash. :man_facepalming: 