### PR TITLE
Make determining buildout path independent of working directory

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make determining buildout path independent of working directory.
+  [lgraf]
 
 
 1.0.2 (2017-09-04)

--- a/ftw/contentstats/console.py
+++ b/ftw/contentstats/console.py
@@ -1,4 +1,6 @@
 from contextlib import closing
+from os.path import abspath
+from os.path import join
 from path import Path
 import argparse
 import re
@@ -67,8 +69,14 @@ def dump_stats_cmd():
 # resources.
 
 
+def get_buildout_path():
+    # Path to bin/dump-content-stats script
+    script_path = sys.argv[0]
+    return Path(abspath(join(script_path, '..', '..')))
+
+
 def get_zope_url():
-    instance = get_running_instance(Path.getcwd())
+    instance = get_running_instance(get_buildout_path())
     if not instance:
         raise NoRunningInstanceFound()
     return 'http://localhost:{0}/'.format(instance['port'])


### PR DESCRIPTION
Make determining buildout path independent of working directory. Instead, determine it relative to the location of the `bin/dump-content-stats` script.

Fixes invocations of the `bin/dump-content-stats` scripts from cron-jobs or other situations where the working directory isn't meaningful.