### PR TITLE
Include disk usage (Data.fs and blobstorage) in stats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ Out of the box, ``ftw.contentstats`` will collect statistics for
 
 - **Types** (distinct ``portal_type``'s and their counts)
 - **Workflow states** (distinct ``review_state``'s and their counts)
+- **Disk Usage** (total disk usage of the deployment directory, filestorage and blobstorage)
 
 Add-on packages can have additional statistics collected by providing an
 ``IStatsProvider`` adapter (see interface description for details).

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- Include disk usage (Data.fs and blobstorage) in stats. [lgraf]
+
 - Add Plone 5 compatibility. [phgross]
 
 1.0.3 (2017-09-08)

--- a/ftw/contentstats/console.py
+++ b/ftw/contentstats/console.py
@@ -1,18 +1,9 @@
-from contextlib import closing
 from distutils.spawn import find_executable
-from os.path import abspath
-from os.path import join
-from path import Path
+from ftw.contentstats.utils import get_zope_url
 import argparse
 import os
-import re
 import requests
-import socket
 import sys
-
-
-class NoRunningInstanceFound(Exception):
-    pass
 
 
 def parse_args():
@@ -75,58 +66,3 @@ def dump_stats_cmd():
             print response.content
             print repr(response)
             sys.exit(1)
-
-
-# XXX: These helper functions have been copied over from ftw.upgrade
-#
-# Unfortunately there's no trivial way to get port of a potentially
-# running Zope instance without resorting to bin/instance [zopectl_command]
-# style commands.
-#
-# And those pose an operational risk when invoked by a scheduled job, because
-# they'll indefinitely keep trying to connect to ZEO instead of terminating
-# when ZEO is not running. This leads to more and more processes accumulating,
-# and the system eventually running out of file descriptors, memory or other
-# resources.
-
-
-def get_buildout_path():
-    # Path to bin/dump-content-stats script
-    script_path = sys.argv[0]
-    return Path(abspath(join(script_path, '..', '..')))
-
-
-def get_zope_url():
-    instance = get_running_instance(get_buildout_path())
-    if not instance:
-        raise NoRunningInstanceFound()
-    return 'http://localhost:{0}/'.format(instance['port'])
-
-
-def get_running_instance(buildout_path):
-    for zconf in find_instance_zconfs(buildout_path):
-        port = get_instance_port(zconf)
-        if not port:
-            continue
-        if is_port_open(port):
-            return {'port': port,
-                    'path': zconf.dirname().dirname()}
-    return None
-
-
-def find_instance_zconfs(buildout_path):
-    return sorted(buildout_path.glob('parts/*/etc/zope.conf'))
-
-
-def get_instance_port(zconf):
-    match = re.search(r'address ([\d.]*:)?(\d+)', zconf.text())
-    if match:
-        return int(match.group(2))
-    return None
-
-
-def is_port_open(port):
-    result = -1
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
-        result = sock.connect_ex(('127.0.0.1', port))
-    return result == 0

--- a/ftw/contentstats/console.py
+++ b/ftw/contentstats/console.py
@@ -1,4 +1,6 @@
 from distutils.spawn import find_executable
+from ftw.contentstats.disk_usage import DiskUsageCalculator
+from ftw.contentstats.utils import get_buildout_path
 from ftw.contentstats.utils import get_zope_url
 import argparse
 import os
@@ -46,9 +48,15 @@ def renice():
 def dump_stats_cmd():
     """Will dump content stats to logfile via the @@dump-content-stats view.
     """
+    args = parse_args()
+
+    # Lower CPU and I/O scheduling priority
     renice()
 
-    args = parse_args()
+    # Calculate disk usage stats and dump them to var/log/disk-usage.json
+    deployment_path = get_buildout_path()
+    DiskUsageCalculator(deployment_path).calc_and_dump()
+
     zope_url = get_zope_url()
     plone_url = ''.join((zope_url, args.site_id))
     dump_stats_url = '/'.join((plone_url, '@@dump-content-stats'))

--- a/ftw/contentstats/disk_usage.py
+++ b/ftw/contentstats/disk_usage.py
@@ -1,0 +1,166 @@
+"""Contains functions to calculate disk usage stats of a deployment.
+
+These are intended to be run from the bin/dump-content-stats script (outside
+a Plone process), and write the resulting stats to var/log/disk-usage.json
+in order to be picked up by the @@dump-content-stats view later.
+"""
+
+from datetime import datetime
+from distutils.spawn import find_executable
+from subprocess import check_output
+import json
+import os
+import shlex
+import sys
+
+
+class DiskUsageCalculator(object):
+
+    du_stats_path = 'var/log/disk-usage.json'
+
+    def __init__(self, deployment_path):
+        self.deployment_path = deployment_path
+        self.du_executable = None
+
+        # This facilitates testing without actually running `du`
+        self.du_outputs = {}
+
+    def calc_and_dump(self):
+        """Calculate disk usage stats and dump them.
+
+        Results will be written to a JSON file in var/log/ for pickup by the
+        @@dump-content-stats view (we don't want to run I/O heavy and potentially
+        long running jobs like this from inside a Zope instance).
+        """
+        self.du_executable = get_du_executable()
+        if self.du_executable is None:
+            print "No suitable `du` executable found, skipping disk usage"
+            return
+
+        du_stats = self.calc_du_stats()
+        self.dump(du_stats)
+
+    def calc_du_stats(self):
+        """Determine disk usage (using `du`) for Data.fs and blobstorage.
+
+        Returns a dictionary with separate keys for total deployment size and
+        individual subtrees.
+        """
+        # Calculate an accurate total first
+        disk_usage_total = self.calc_du_total()
+
+        # Calculate size of individual subdirectories / files
+        disk_usage_subtrees = self.calc_du_subtrees()
+
+        du_stats = {}
+        du_stats['deployment'] = self.deployment_path
+        du_stats['updated'] = datetime.now().isoformat()
+        du_stats['total'] = disk_usage_total
+        du_stats['subtrees'] = disk_usage_subtrees
+        return du_stats
+
+    def calc_du_total(self):
+        """Calculate an accurate total for the deployment directory.
+
+        Sum up the size of the entire deployment directory, counting hardlinked
+        files only once, and using actual FS block usage (not apparent size).
+        This correctly reports the real disk usage of the deployment, accounting
+        for hardlinks, sparse files and files smaller than the FS block size.
+
+        Returns the total size in bytes as an integer.
+        """
+        if 'total' not in self.du_outputs:
+            du_total_cmd = '%s -s -B1 %s' % (self.du_executable, self.deployment_path)
+            self.du_outputs['total'] = self.run(du_total_cmd)
+
+        disk_usage_total = self.parse_du_output(self.du_outputs['total'])
+
+        # We have exactly one result line, the deployment directory itself
+        assert disk_usage_total.keys() == ['']
+        return disk_usage_total['']
+
+    def calc_du_subtrees(self):
+        """Calculate size of individual subdirectories / files in deployment dir.
+
+        This is needed to report database size (Data.fs, blobstorage) without
+        accounting for hardlinks. We actually want to count hardlinks twice,
+        because otherwise we would be dependent on `du` counting blobstorage
+        and blobstorage.old in exactly the right order.
+
+        This listing might eventually also be used by agent.smith to replace
+        the `du/big` command.
+        """
+        if 'subtrees' not in self.du_outputs:
+            du_subtrees_cmd = '%s -x -a -B1 --count-links --apparent-size --max-depth=3 %s' % (
+                self.du_executable, self.deployment_path)
+            self.du_outputs['subtrees'] = self.run(du_subtrees_cmd)
+
+        disk_usage_subtrees = self.parse_du_output(self.du_outputs['subtrees'])
+
+        # Remove total, because it's inaccurate in this run
+        disk_usage_subtrees.pop('')
+
+        # Reduce subtree depth to 2, except for var/filestorage/*
+        # (We need the size of Data.fs, which is 3 levels deep)
+        for key in disk_usage_subtrees.keys():
+            path = key.lstrip('/')
+            if path.count(os.sep) > 1 and 'filestorage' not in path:
+                disk_usage_subtrees.pop(key)
+        return disk_usage_subtrees
+
+    def parse_du_output(self, output):
+        """Parse output of a 'du ...' command.
+
+        Returns a dict (path -> size_in_bytes) with paths relative to the deployment
+        directory.
+        """
+        disk_usage = {}
+        lines = map(str.strip, output.strip().splitlines())
+        for line in lines:
+            size_in_bytes, path = map(str.strip, line.split())
+            size_in_bytes = int(size_in_bytes)
+            assert path.startswith(self.deployment_path)
+            path = path.replace(self.deployment_path, '', 1).lstrip('/')
+            disk_usage[path] = size_in_bytes
+
+        return disk_usage
+
+    def run(self, cmd):
+        return check_output(shlex.split(cmd))
+
+    def dump(self, du_stats):
+        """Dump disk usage to file for pickup by @@dump-content-stats view
+        (or, eventually, agent.smith)
+        """
+        du_stats_path = os.path.join(self.deployment_path, self.du_stats_path)
+        with open(du_stats_path, 'w') as du_stats_file:
+            json.dump(du_stats, du_stats_file)
+
+
+def get_du_executable():
+    """Get path to `du` (Linux) or `gdu` (Mac OS).
+
+    The flags we need for `du` are not supported by the default *BSD-style
+    `du` that is shipped with Mac OS. However, the GNU-style `du` can be
+    installed on Mac OS (as `gdu`), so we attempt to look for it's presence.
+    This way, the disk usage aspect can still be tested locally on Mac OS.
+    """
+    if sys.platform == 'darwin':
+        du_executable = find_executable('gdu')
+        if du_executable is None:
+            print "WARNING: Unable to locate `gdu` executable."
+            print
+            print "Disk usage stats will not be computed."
+            print
+            print "If you want to test disk usage stats on Mac OS, you need"
+            print "to install GNU coreutils to get the GNU-style du command"
+            print "(installed as `gdu`):"
+            print
+            print "  brew install coreutils"
+            print
+
+        return du_executable
+
+    else:
+        du_executable = find_executable('du')
+        return du_executable

--- a/ftw/contentstats/logger.py
+++ b/ftw/contentstats/logger.py
@@ -33,11 +33,11 @@ def setup_logger():
     return logger
 
 
-def get_logfile_path():
-    """Determine the path for our JSON log.
+def get_log_dir_path():
+    """Determine the path of the deployment's var/log/ directory.
 
     This will be derived from Zope2's EventLog location, in order to not
-    have to figure out the path to var/log/ and the instance name ourselves.
+    have to figure out the path to var/log/ ourselves from buildout.
     """
     zconf = getConfiguration()
     eventlog = getattr(zconf, 'eventlog', None)
@@ -54,6 +54,13 @@ def get_logfile_path():
     handler_factories = eventlog.handler_factories
     eventlog_path = handler_factories[0].section.path
     log_dir = dirname(eventlog_path)
+    return log_dir
+
+
+def get_logfile_path():
+    """Determine the path for our JSON log.
+    """
+    log_dir = get_log_dir_path()
     path = join(log_dir, 'contentstats-json.log')
     return path
 

--- a/ftw/contentstats/providers/configure.zcml
+++ b/ftw/contentstats/providers/configure.zcml
@@ -4,5 +4,6 @@
 
     <adapter factory=".portal_types.PortalTypesProvider" name="portal_types" />
     <adapter factory=".review_states.ReviewStatesProvider" name="review_states" />
+    <adapter factory=".disk_usage.DiskUsageProvider" name="disk_usage" />
 
 </configure>

--- a/ftw/contentstats/providers/disk_usage.py
+++ b/ftw/contentstats/providers/disk_usage.py
@@ -1,0 +1,54 @@
+from ftw.contentstats.interfaces import IStatsProvider
+from ftw.contentstats.logger import get_log_dir_path
+from logging import getLogger
+from os.path import join
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+import json
+
+
+log = getLogger()
+
+
+@implementer(IStatsProvider)
+@adapter(IPloneSiteRoot, Interface)
+class DiskUsageProvider(object):
+    """Reads disk usage statistics from a file in var/log/disk-usage.json.
+
+    This file gets created/updated by the bin/dump-content-stats script.
+    """
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def title(self):
+        """Human readable title
+        """
+        return u'Disk usage statistics'
+
+    def get_raw_stats(self):
+        """Returns a dict with disk usage stats.
+        """
+        log_dir = get_log_dir_path()
+        path = join(log_dir, 'disk-usage.json')
+        try:
+            with open(path) as disk_usage_file:
+                disk_usage = json.load(disk_usage_file)
+        except IOError:
+            log.warn('Unable to read disk usage stats from %r' % path)
+            return {}
+
+        # XXX: The paths to filestorage and blobstorage could eventually be
+        # determined dynamically (ZODB APIs should be able to tell us).
+
+        stats = {}
+        stats['total'] = disk_usage['total']
+        stats['filestorage'] = disk_usage['subtrees']['var/filestorage/Data.fs']
+        stats['blobstorage'] = disk_usage['subtrees']['var/blobstorage']
+        return stats
+
+    def get_display_names(self):
+        return None

--- a/ftw/contentstats/tests/assets/__init__.py
+++ b/ftw/contentstats/tests/assets/__init__.py
@@ -1,0 +1,10 @@
+from pkg_resources import resource_filename
+from pkg_resources import resource_string
+
+
+def load(asset_filename):
+    return resource_string('ftw.contentstats.tests.assets', asset_filename)
+
+
+def path_to_asset(asset_filename):
+    return resource_filename('ftw.contentstats.tests.assets', asset_filename)

--- a/ftw/contentstats/tests/assets/disk-usage.json
+++ b/ftw/contentstats/tests/assets/disk-usage.json
@@ -1,0 +1,13 @@
+{
+    "deployment": "/path/to/deployment",
+    "updated": "2018-12-30T12:45:00",
+    "subtrees": {
+        "bin": 10,
+        "bin/instance": 5,
+        "var/blobstorage": 45,
+        "var/filestorage/Data.fs": 20,
+        "var/filestorage/Data.fs.index": 25,
+        "var/log": 15
+    },
+    "total": 1024
+}

--- a/ftw/contentstats/tests/test_disk_usage.py
+++ b/ftw/contentstats/tests/test_disk_usage.py
@@ -1,0 +1,139 @@
+from datetime import datetime
+from ftw.contentstats.disk_usage import DiskUsageCalculator
+from ftw.contentstats.tests import assets
+from ftw.testing import freeze
+from textwrap import dedent
+from unittest import TestCase
+import json
+
+
+FROZEN_NOW = datetime(2018, 12, 30, 12, 45)
+
+
+class TestDiskUsageCalculator(TestCase):
+
+    def setUp(self):
+        self.deployment_path = '/path/to/deployment'
+
+    def test_parse_du_output_total(self):
+        calculator = DiskUsageCalculator(self.deployment_path)
+        output_total = dedent("""\
+        1024   /path/to/deployment
+        """)
+        disk_usage = calculator.parse_du_output(output_total)
+        self.assertEqual({'': 1024}, disk_usage)
+
+    def test_parse_du_output_subtrees(self):
+        calculator = DiskUsageCalculator(self.deployment_path)
+        output_subtrees = dedent("""\
+        5  /path/to/deployment/bin/instance
+        10 /path/to/deployment/bin
+        15 /path/to/deployment/var/log
+        20 /path/to/deployment/var/filestorage/Data.fs
+        25 /path/to/deployment/var/filestorage/Data.fs.index
+        35 /path/to/deployment/var/blobstorage/0x00
+        40 /path/to/deployment/var/blobstorage/tmp
+        45 /path/to/deployment/var/blobstorage
+        50 /path/to/deployment
+        """)
+        disk_usage = calculator.parse_du_output(output_subtrees)
+        self.assertEqual({'': 50,
+                          'bin': 10,
+                          'bin/instance': 5,
+                          'var/blobstorage': 45,
+                          'var/blobstorage/0x00': 35,
+                          'var/blobstorage/tmp': 40,
+                          'var/filestorage/Data.fs': 20,
+                          'var/filestorage/Data.fs.index': 25,
+                          'var/log': 15},
+                         disk_usage)
+
+    def test_parse_du_output_strips_whitespace(self):
+        calculator = DiskUsageCalculator(self.deployment_path)
+        output_whitespace = """
+
+        1024   /path/to/deployment/foo
+        1024   \t\t/path/to/deployment/bar
+        2048      /path/to/deployment\t
+
+        """
+        disk_usage = calculator.parse_du_output(output_whitespace)
+        self.assertEqual({'': 2048,
+                          'bar': 1024,
+                          'foo': 1024},
+                         disk_usage)
+
+    def test_calc_du_total(self):
+        calculator = DiskUsageCalculator(self.deployment_path)
+        calculator.du_outputs['total'] = dedent("""\
+        1024   /path/to/deployment
+        """)
+        disk_usage = calculator.calc_du_total()
+        self.assertEqual(1024, disk_usage)
+
+    def test_calc_du_subtrees(self):
+        calculator = DiskUsageCalculator(self.deployment_path)
+        calculator.du_outputs['subtrees'] = dedent("""\
+        5  /path/to/deployment/bin/instance
+        10 /path/to/deployment/bin
+        15 /path/to/deployment/var/log
+        20 /path/to/deployment/var/filestorage/Data.fs
+        25 /path/to/deployment/var/filestorage/Data.fs.index
+        35 /path/to/deployment/var/blobstorage/0x00
+        40 /path/to/deployment/var/blobstorage/tmp
+        45 /path/to/deployment/var/blobstorage
+        50 /path/to/deployment
+        """)
+        disk_usage = calculator.calc_du_subtrees()
+
+        # Should reduce subtree depth to 2 levels, except for var/filestorage/*
+        self.assertEqual({'bin': 10,
+                          'bin/instance': 5,
+                          'var/blobstorage': 45,
+                          'var/filestorage/Data.fs': 20,
+                          'var/filestorage/Data.fs.index': 25,
+                          'var/log': 15},
+                         disk_usage)
+
+    def test_calc_du_stats(self):
+        calculator = DiskUsageCalculator(self.deployment_path)
+
+        calculator.du_outputs['subtrees'] = dedent("""\
+        5  /path/to/deployment/bin/instance
+        10 /path/to/deployment/bin
+        15 /path/to/deployment/var/log
+        20 /path/to/deployment/var/filestorage/Data.fs
+        25 /path/to/deployment/var/filestorage/Data.fs.index
+        35 /path/to/deployment/var/blobstorage/0x00
+        40 /path/to/deployment/var/blobstorage/tmp
+        45 /path/to/deployment/var/blobstorage
+        50 /path/to/deployment
+        """)
+
+        calculator.du_outputs['total'] = dedent("""\
+        1024   /path/to/deployment
+        """)
+
+        with freeze(FROZEN_NOW):
+            du_stats = calculator.calc_du_stats()
+
+        # Should reduce subtree depth to 2 levels, except for var/filestorage/*
+        self.assertEqual({'deployment': '/path/to/deployment',
+                          'updated': FROZEN_NOW.isoformat(),
+                          'total': 1024,
+                          'subtrees': {'bin': 10,
+                                       'bin/instance': 5,
+                                       'var/blobstorage': 45,
+                                       'var/filestorage/Data.fs': 20,
+                                       'var/filestorage/Data.fs.index': 25,
+                                       'var/log': 15},
+                          },
+                         du_stats)
+
+        # Ensure the du_stats format matches our asset file which is also
+        # used to test the provider. Since this is the interchange format
+        # between the bin/dump-content-stats script that dumps it and the
+        # @@dump-content-stats view that reads it, we need to make sure
+        # these implementations stay in sync.
+        asset = json.loads(assets.load('disk-usage.json'))
+        self.assertEqual(asset, du_stats)

--- a/ftw/contentstats/tests/test_disk_usage_provider.py
+++ b/ftw/contentstats/tests/test_disk_usage_provider.py
@@ -1,0 +1,42 @@
+from ftw.contentstats.interfaces import IStatsProvider
+from ftw.contentstats.logger import get_log_dir_path
+from ftw.contentstats.tests import assets
+from ftw.contentstats.tests import FunctionalTestCase
+from os.path import join
+from zope.component import getMultiAdapter
+import os
+
+
+class TestDiskUsageProvider(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDiskUsageProvider, self).setUp()
+        self.grant('Manager')
+
+        self.provider = getMultiAdapter((self.portal, self.portal.REQUEST),
+                                        IStatsProvider,
+                                        name='disk_usage')
+
+        log_dir = get_log_dir_path()
+        self.disk_usage_path = join(log_dir, 'disk-usage.json')
+
+    def tearDown(self):
+        super(TestDiskUsageProvider, self).tearDown()
+        try:
+            os.unlink(self.disk_usage_path)
+        except OSError:
+            pass
+
+    def test_disk_usage_empty_if_file_not_present(self):
+        disk_usage = self.provider.get_raw_stats()
+        self.assertEqual({}, disk_usage)
+
+    def test_disk_usage_getting_read_from_json_file(self):
+        with open(self.disk_usage_path, 'w') as disk_usage_file:
+            disk_usage_file.write(assets.load('disk-usage.json'))
+
+        disk_usage = self.provider.get_raw_stats()
+        self.assertEqual({'blobstorage': 45,
+                          'filestorage': 20,
+                          'total': 1024},
+                         disk_usage)

--- a/ftw/contentstats/tests/test_dump_stats_view.py
+++ b/ftw/contentstats/tests/test_dump_stats_view.py
@@ -34,12 +34,14 @@ class TestContentStatsView(FunctionalTestCase):
         log_entry = self.get_log_entries()[-1]
 
         self.assertEquals(
-            [u'review_states', u'portal_types', u'site', u'timestamp'],
+            [u'disk_usage', u'review_states', u'portal_types', u'site', u'timestamp'],
             log_entry.keys())
 
         self.assertEquals(
             {u'Folder': 1, u'Document': 2},
             log_entry['portal_types'])
+
+        self.assertEquals({}, log_entry['disk_usage'])
 
     @browsing
     def test_access_from_localhost_allowed_for_anonymous(self, browser):

--- a/ftw/contentstats/tests/test_stats.py
+++ b/ftw/contentstats/tests/test_stats.py
@@ -35,7 +35,7 @@ class TestContentStats(FunctionalTestCase):
             verifyClass(IStatsProvider, provider.__class__)
 
     def test_get_all_provider_names(self):
-        self.assertEquals(['portal_types', 'review_states'],
+        self.assertEquals(['portal_types', 'review_states', 'disk_usage'],
                           self.stats_util.get_provider_names())
 
     def test_stats_contain_portal_types_stats(self):
@@ -61,3 +61,10 @@ class TestContentStats(FunctionalTestCase):
 
         self.assertEquals(u'Review state statistics',
                           stats['review_states']['title'])
+
+    def test_stats_contain_disk_usage_stats(self):
+        stats = self.stats_util.get_human_readable_stats()
+        self.assertIn('disk_usage', stats)
+
+        self.assertEquals(u'Disk usage statistics',
+                          stats['disk_usage']['title'])

--- a/ftw/contentstats/utils.py
+++ b/ftw/contentstats/utils.py
@@ -1,0 +1,66 @@
+from contextlib import closing
+from os.path import abspath
+from os.path import join
+from path import Path
+import re
+import socket
+import sys
+
+
+# XXX: These helper functions have been copied over from ftw.upgrade
+#
+# Unfortunately there's no trivial way to get the port of a potentially
+# running Zope instance without resorting to bin/instance [zopectl_command]
+# style commands.
+#
+# And those pose an operational risk when invoked by a scheduled job, because
+# they'll indefinitely keep trying to connect to ZEO instead of terminating
+# when ZEO is not running. This leads to more and more processes accumulating,
+# and the system eventually running out of file descriptors, memory or other
+# resources.
+
+
+class NoRunningInstanceFound(Exception):
+    pass
+
+
+def get_buildout_path():
+    # Path to bin/dump-content-stats script
+    script_path = sys.argv[0]
+    return Path(abspath(join(script_path, '..', '..')))
+
+
+def get_zope_url():
+    instance = get_running_instance(get_buildout_path())
+    if not instance:
+        raise NoRunningInstanceFound()
+    return 'http://localhost:{0}/'.format(instance['port'])
+
+
+def get_running_instance(buildout_path):
+    for zconf in find_instance_zconfs(buildout_path):
+        port = get_instance_port(zconf)
+        if not port:
+            continue
+        if is_port_open(port):
+            return {'port': port,
+                    'path': zconf.dirname().dirname()}
+    return None
+
+
+def find_instance_zconfs(buildout_path):
+    return sorted(buildout_path.glob('parts/*/etc/zope.conf'))
+
+
+def get_instance_port(zconf):
+    match = re.search(r'address ([\d.]*:)?(\d+)', zconf.text())
+    if match:
+        return int(match.group(2))
+    return None
+
+
+def is_port_open(port):
+    result = -1
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        result = sock.connect_ex(('127.0.0.1', port))
+    return result == 0


### PR DESCRIPTION
Disk usage stats are gathered using the `du` utility. In order to avoid running an I/O heavy and potentially long running process like `du` from inside a Zope instance, this is being done from the `bin/dump-content-stats` wrapper script.

This script invokes `du`, stores the results in a JSON file, and then triggers the `@@dump-content-stats` view as usual.

That view then picks up the disk usage stats from that file (if present), and includes them in the dumped stats.

Closes 4teamwork/opengever.core#4675