### PR TITLE
Add perf_metrics provider that gathers performance metrics from ftw.monitor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,9 @@ Out of the box, ``ftw.contentstats`` will collect statistics for
 Add-on packages can have additional statistics collected by providing an
 ``IStatsProvider`` adapter (see interface description for details).
 
+If ``ftw.monitor`` is installed, its performance metrics will also be
+included, grouped by instance.
+
 
 Logging content stats over time
 ===============================

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-1.1.2 (unreleased)
+1.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add perf_metrics provider that gathers performance metrics from ftw.monitor. [lgraf]
 
 
 1.1.1 (2018-12-28)

--- a/ftw/contentstats/browser/templates/content_stats.pt
+++ b/ftw/contentstats/browser/templates/content_stats.pt
@@ -25,7 +25,7 @@
 
 
         <div class="statistic-wrapper"
-            tal:repeat="stat view/get_all_stats">
+            tal:repeat="stat view/get_visualized_stats">
 
             <tal:statistic tal:define="stat_name python: stat[0];
                                        stat_title python: stat[1]['title'];

--- a/ftw/contentstats/providers/configure.zcml
+++ b/ftw/contentstats/providers/configure.zcml
@@ -1,9 +1,14 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.contentstats">
 
     <adapter factory=".portal_types.PortalTypesProvider" name="portal_types" />
     <adapter factory=".review_states.ReviewStatesProvider" name="review_states" />
     <adapter factory=".disk_usage.DiskUsageProvider" name="disk_usage" />
+
+    <configure zcml:condition="installed ftw.monitor">
+      <adapter factory=".perf_metrics.PerformanceMetricsProvider" name="perf_metrics" />
+    </configure>
 
 </configure>

--- a/ftw/contentstats/providers/perf_metrics.py
+++ b/ftw/contentstats/providers/perf_metrics.py
@@ -1,0 +1,149 @@
+from App.config import getConfiguration
+from ftw.contentstats.interfaces import IStatsProvider
+from ftw.contentstats.logger import root_logger as logger
+from glob import glob
+from os.path import basename
+from os.path import join as pjoin
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+from ZServer.medusa.http_server import http_server
+import json
+import re
+import socket
+
+
+INSTANCE_NAME_PATTERN = re.compile(r'instance(\d+)')
+
+
+@implementer(IStatsProvider)
+@adapter(IPloneSiteRoot, Interface)
+class PerformanceMetricsProvider(object):
+    """Gathers performance metrics from ftw.monitor (if installed).
+    """
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def title(self):
+        return u'Performance metrics'
+
+    def get_raw_stats(self):
+        """Return a dict with performance metrics.
+        """
+        stats = {}
+
+        try:
+            monitor_ports = get_monitor_ports(self.request)
+        except Exception as exc:
+            logger.warn('Failed to determine monitor ports: %r' % exc)
+            return {}
+
+        monitor_ports = get_monitor_ports(self.request)
+        logger.info('Selected monitor ports for dumping perf_metrics: %r' % monitor_ports)
+        for instance_name, monitor_port in monitor_ports.items():
+            try:
+                reply = netcat('127.0.0.1', monitor_port,
+                               'perf_metrics\n').strip()
+                instance_metrics = json.loads(reply)
+                stats[instance_name] = instance_metrics
+            except Exception as exc:
+                logger.warn('Failed to gather perf_metrics from %s: %r' % (instance_name, exc))
+
+        return stats
+
+    def get_display_names(self):
+        return None
+
+
+def get_monitor_ports(request):
+    """Get a list of open ftw.monitor ports for instances of this deployment.
+
+    This will:
+    - Determine which bin/instance* scripts belong to this deployment
+    - Determine the instance numbers from them
+    - Determine the port base via the ZServer port of the current instance
+    - Build the map of monitor ports by instance by doing port arithmetic:
+      monitor_port = port base + instance number + 80
+      (According to 4tw port schema and ftw.monitor port strategy)
+    """
+    config = getConfiguration()
+    instance_scripts = get_instance_scripts(config)
+    instance_names = get_instance_names(instance_scripts)
+
+    zserver_port = get_zserver_port(config)
+    if zserver_port == 8080:
+        # Local development
+        return {'instance': 8160}
+
+    port_base = get_port_base(zserver_port)
+
+    monitor_ports_by_instance = {}
+    for name in instance_names:
+        if name in ('instance0', 'instance'):
+            # Ignore maintenance or development instances
+            continue
+
+        number = get_instance_number(name)
+        if number:
+            monitor_port = port_base + number + 80
+            monitor_ports_by_instance[name] = monitor_port
+
+    return monitor_ports_by_instance
+
+
+def get_buildout_dir(config):
+    buildout_dir = config.instancehome.partition('/parts/')[0]
+    return buildout_dir
+
+
+def get_instance_scripts(config):
+    buildout_dir = get_buildout_dir(config)
+    bin_dir = pjoin(buildout_dir, 'bin')
+    instance_scripts = glob(pjoin(bin_dir, 'instance*'))
+    return instance_scripts
+
+
+def get_instance_names(instance_scripts):
+    return [basename(path) for path in instance_scripts]
+
+
+def get_instance_number(instance_name):
+    match = INSTANCE_NAME_PATTERN.match(instance_name)
+    if match:
+        number = int(match.group(1))
+        return number
+
+
+def get_zserver_port(config):
+    zservers = [
+        server for server in config.servers
+        if isinstance(server, http_server)
+    ]
+
+    zserver_ports = [zs.port for zs in zservers]
+
+    assert len(zserver_ports) == 1
+    zserver_port = zserver_ports[0]
+    return zserver_port
+
+
+def get_port_base(zserver_port):
+    return int(str(zserver_port)[:-2] + '00')
+
+
+def netcat(hostname, port, content):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((hostname, port))
+    s.sendall(content)
+
+    result = ''
+    while 1:
+        data = s.recv(1024)
+        if data == '':
+            break
+        result += data
+    s.close()
+    return result

--- a/ftw/contentstats/testing.py
+++ b/ftw/contentstats/testing.py
@@ -5,6 +5,7 @@ from ftw.builder.testing import set_builder_session_factory
 from ftw.contentstats.logger import setup_logger
 from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
 from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
+from pkg_resources import DistributionNotFound
 from pkg_resources import get_distribution
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
@@ -21,6 +22,13 @@ import ZConfig
 
 
 IS_PLONE_5_OR_GREATER = get_distribution('Plone').version >= '5'
+
+
+try:
+    get_distribution('ftw.monitor')
+    FTW_MONITOR_INSTALLED = True
+except DistributionNotFound:
+    FTW_MONITOR_INSTALLED = False
 
 
 def get_log_path():

--- a/ftw/contentstats/tests/__init__.py
+++ b/ftw/contentstats/tests/__init__.py
@@ -1,5 +1,6 @@
 from ftw.contentstats.testing import CONTENTSTATS_FUNCTIONAL
 from ftw.contentstats.testing import get_log_path
+from mock import patch
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -16,6 +17,15 @@ class FunctionalTestCase(TestCase):
         self.portal = self.layer['portal']
         self.request = self.layer['request']
         self.load_zcml_string = self.layer['load_zcml_string']
+
+        # Prevent get_monitor_ports() from interfering with tests that
+        # don't run on a ftw.monitor layer
+        self.patched_get_monitor_ports = patch(
+            'ftw.contentstats.providers.perf_metrics.get_monitor_ports'
+        ).__enter__()
+
+    def tearDown(self):
+        self.patched_get_monitor_ports.__exit__()
 
     def grant(self, *roles):
         setRoles(self.portal, TEST_USER_ID, list(roles))

--- a/ftw/contentstats/tests/__init__.py
+++ b/ftw/contentstats/tests/__init__.py
@@ -3,7 +3,7 @@ from ftw.contentstats.testing import get_log_path
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from unittest import TestCase
 import json
 import os
 import transaction

--- a/ftw/contentstats/tests/test_dump_stats_view.py
+++ b/ftw/contentstats/tests/test_dump_stats_view.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.contentstats.testing import CONTENTSTATS_FUNCTIONAL_ZSERVER
+from ftw.contentstats.testing import FTW_MONITOR_INSTALLED
 from ftw.contentstats.tests import FunctionalTestCase
 from ftw.testbrowser import browsing
 from requests_toolbelt.adapters.source import SourceAddressAdapter
@@ -33,9 +34,17 @@ class TestContentStatsView(FunctionalTestCase):
         browser.open(self.portal, view='@@dump-content-stats', method='POST')
         log_entry = self.get_log_entries()[-1]
 
-        self.assertEquals(
-            [u'disk_usage', u'review_states', u'portal_types', u'site', u'timestamp'],
-            log_entry.keys())
+        expected_stats = [
+            'site',
+            'disk_usage',
+            'portal_types',
+            'review_states',
+            'timestamp',
+        ]
+        if FTW_MONITOR_INSTALLED:
+            expected_stats.append('perf_metrics')
+
+        self.assertItemsEqual(expected_stats, log_entry.keys())
 
         self.assertEquals(
             {u'Folder': 1, u'Document': 2},

--- a/ftw/contentstats/tests/test_logger.py
+++ b/ftw/contentstats/tests/test_logger.py
@@ -4,6 +4,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.contentstats.logger import get_log_dir_path
 from ftw.contentstats.logger import log_stats_to_file
+from ftw.contentstats.testing import FTW_MONITOR_INSTALLED
 from ftw.contentstats.testing import PatchedLogTZ
 from ftw.contentstats.tests import assets
 from ftw.contentstats.tests import FunctionalTestCase
@@ -45,9 +46,18 @@ class TestLogging(FunctionalTestCase):
         log_stats_to_file()
         log_entry = self.get_log_entries()[-1]
 
-        self.assertItemsEqual(
-            [u'site', u'timestamp', u'disk_usage', u'portal_types', u'review_states'],
-            log_entry.keys())
+        expected_stats_names = [
+            'site',
+            'timestamp',
+            'disk_usage',
+            'portal_types',
+            'review_states',
+        ]
+
+        if FTW_MONITOR_INSTALLED:
+            expected_stats_names.append('perf_metrics')
+
+        self.assertItemsEqual(expected_stats_names, log_entry.keys())
 
         self.assertEquals(
             {u'Folder': 1, u'Document': 2},

--- a/ftw/contentstats/tests/test_perf_metrics_provider.py
+++ b/ftw/contentstats/tests/test_perf_metrics_provider.py
@@ -1,0 +1,69 @@
+from ftw.contentstats.interfaces import IStatsProvider
+from ftw.contentstats.providers.perf_metrics import get_buildout_dir
+from ftw.contentstats.providers.perf_metrics import get_instance_names
+from ftw.contentstats.providers.perf_metrics import get_instance_number
+from ftw.contentstats.providers.perf_metrics import get_port_base
+from ftw.contentstats.testing import FTW_MONITOR_INSTALLED
+from mock import Mock
+from mock import patch
+from plone.testing import Layer
+from unittest import skipUnless
+from unittest import TestCase
+from ZODB.interfaces import IDatabase
+from zope.component import getMultiAdapter
+from zope.component import provideUtility
+
+
+if FTW_MONITOR_INSTALLED:
+    from ftw.monitor.testing import MONITOR_ZSERVER_TESTING
+    from ftw.monitor.testing import MonitorTestCase
+else:
+    MonitorTestCase = TestCase
+    MONITOR_ZSERVER_TESTING = Layer(name='stub')
+
+
+@skipUnless(FTW_MONITOR_INSTALLED, 'Requires ftw.monitor to run')
+class TestPerfMetricsProvider(MonitorTestCase):
+
+    layer = MONITOR_ZSERVER_TESTING
+
+    @patch('ftw.contentstats.providers.perf_metrics.get_monitor_ports')
+    def test_reports_loads_and_stores(self, mocked_get_monitor_ports):
+        mocked_get_monitor_ports.return_value = {
+            'instance99': MonitorTestCase.MONITOR_PORT}
+
+        # Plone's testing DB is named 'unnamed' in tests. Also register it
+        # as 'main' in order for ftw.monitor to be able to pick it up
+        db = self.layer['portal']._p_jar.db()
+        provideUtility(db, IDatabase, name='main')
+
+        provider = getMultiAdapter(
+            (self.layer['portal'], self.portal.REQUEST),
+            IStatsProvider, name='perf_metrics')
+
+        perf_metrics = provider.get_raw_stats()
+
+        actual_categories = perf_metrics['instance99'].keys()
+        for expected_category in [u'instance', u'cache', u'db', u'memory']:
+            self.assertIn(expected_category, actual_categories)
+
+
+class TestPerfMetricsHelperFunctions(TestCase):
+
+    def test_get_port_base(self):
+        self.assertEqual(14700, get_port_base(14702))
+
+    def test_get_instance_number(self):
+        self.assertIsNone(get_instance_number('instance'))
+        self.assertEqual(1, get_instance_number('instance1'))
+        self.assertEqual(1, get_instance_number('instance01'))
+        self.assertEqual(42, get_instance_number('instance42'))
+
+    def test_get_instance_names(self):
+        instance_scripts = ['bin/instance1', '/path/to/bin/instance2']
+        self.assertEqual(['instance1', 'instance2'],
+                         get_instance_names(instance_scripts))
+
+    def test_get_buildout_dir(self):
+        zconfig = Mock(instancehome='/apps/01-plone/parts/instance1')
+        self.assertEqual('/apps/01-plone', get_buildout_dir(zconfig))

--- a/ftw/contentstats/tests/test_stats.py
+++ b/ftw/contentstats/tests/test_stats.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.contentstats.interfaces import IStatsProvider
 from ftw.contentstats.stats import ContentStats
+from ftw.contentstats.testing import FTW_MONITOR_INSTALLED
 from ftw.contentstats.tests import FunctionalTestCase
 from unittest import TestCase
 from zope.interface.verify import verifyClass
@@ -35,8 +36,16 @@ class TestContentStats(FunctionalTestCase):
             verifyClass(IStatsProvider, provider.__class__)
 
     def test_get_all_provider_names(self):
-        self.assertEquals(['portal_types', 'review_states', 'disk_usage'],
-                          self.stats_util.get_provider_names())
+        expected_provider_names = [
+            'portal_types',
+            'review_states',
+            'disk_usage',
+        ]
+        if FTW_MONITOR_INSTALLED:
+            expected_provider_names.append('perf_metrics')
+
+        self.assertItemsEqual(expected_provider_names,
+                              self.stats_util.get_provider_names())
 
     def test_stats_contain_portal_types_stats(self):
         self.create_content()

--- a/ftw/contentstats/tests/test_uninstall.py
+++ b/ftw/contentstats/tests/test_uninstall.py
@@ -1,6 +1,6 @@
 from ftw.testing.genericsetup import apply_generic_setup_layer
 from ftw.testing.genericsetup import GenericSetupUninstallMixin
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 @apply_generic_setup_layer

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ tests_require = [
     'plone.testing',
     'plone.app.contenttypes',
     'transaction',
-    'unittest2',
     'zope.configuration',
     'freezegun < 0.3.15',
     'requests_toolbelt',

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,13 @@ from setuptools import find_packages
 from setuptools import setup
 import os
 
-version = '1.1.2.dev0'
+version = '1.2.0.dev0'
 
 tests_require = [
     'ftw.builder',
     'ftw.testbrowser',
     'ftw.testing',
+    'mock',
     'plone.app.testing',
     'plone.testing',
     'plone.app.contenttypes',

--- a/test-plone-4.3.x-ftw-monitor.cfg
+++ b/test-plone-4.3.x-ftw-monitor.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    test-plone-4.3.x.cfg
+
+[test]
+eggs += ftw.monitor

--- a/test-plone-5.1.x-ftw-monitor.cfg
+++ b/test-plone-5.1.x-ftw-monitor.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    test-plone-5.1.x.cfg
+
+[test]
+eggs += ftw.monitor


### PR DESCRIPTION
This adds a `perf_metrics` provider that gathers performance metrics from `ftw.monitor` (if installed).

It does so by determining which running instances belong to the current deployment, and querying those instances' `ftw.monitor` ports with the `perf_metrics` command. The performance metrics are then included in the stats, grouped by instance.

Example output:

```json
{
    "review_states": {"...": "..."},
    "perf_metrics": {
        "instance1": {
            "cache": {
                "max_size": 30000,
                "ngsize": 583,
                "size": 1747
            },
            "db": {
                "conflicts": 0,
                "connections": 3,
                "loads": 251,
                "size_in_bytes": 5826190,
                "stores": 0,
                "total_objs": 13340,
                "unresolved_conflicts": 0
            },
            "instance": {
                "uptime": 5
            },
            "memory": {
                "pss": -1,
                "rss": 317435904,
                "uss": 305680384
            }
        },
        "instance2": {
            "cache": {
                "max_size": 30000,
                "ngsize": 251,
                "size": 527
            },
            "...": "..."
    },
    "...": "...",
    "site": "plone",
    "timestamp": "2020-05-01T16:20:51.410703+02:00"
}
```

Jira: https://4teamwork.atlassian.net/browse/GEVER-152