### PR TITLE
Pin tzlocal to version supporting python 2.

### DIFF
--- a/test-plone-4.3.x-ftw-monitor.cfg
+++ b/test-plone-4.3.x-ftw-monitor.cfg
@@ -4,3 +4,7 @@ extends =
 
 [test]
 eggs += ftw.monitor
+
+[versions]
+# tzlocal dropped python 2 support in version 3.0b1
+tzlocal = < 3

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -4,3 +4,7 @@ extends =
     sources.cfg
 
 package-name = ftw.contentstats
+
+[versions]
+# tzlocal dropped python 2 support in version 3.0b1
+tzlocal = < 3

--- a/test-plone-5.1.x-ftw-monitor.cfg
+++ b/test-plone-5.1.x-ftw-monitor.cfg
@@ -4,3 +4,7 @@ extends =
 
 [test]
 eggs += ftw.monitor
+
+[versions]
+# tzlocal dropped python 2 support in version 3.0b1
+tzlocal = < 3

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -4,3 +4,7 @@ extends =
     sources.cfg
 
 package-name = ftw.contentstats
+
+[versions]
+# tzlocal dropped python 2 support in version 3.0b1
+tzlocal = < 3


### PR DESCRIPTION
I have also sorted the pinnings. One could discuss whether `setup.py` would be a better place for this version requirement as the package does not support python3 at all yet.