### PR TITLE
Add support for logging to Fluentd.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,20 @@ location. It's therefore important to have an eventlog configured, otherwise
 ``ftw.contentstats`` will not be able to log any content stats, and complain
 noisily through the root logger.
 
+Logging to Fluentd
+------------------
+
+Instead of logging to a logfile, ``ftw.contentstats`` can also be configured
+to log to a Fluentd instance.
+
+If the environment variable ``FLUENT_HOST`` is set, it will log to that fluent
+host using the Fluentd Forward Protocol, instead of logging to a local file.
+``FLUENT_PORT`` (optional) allows to specify the port, and defaults to 24224
+if not set.
+
+In order for ftw.contentstats to use a proper tag for events logged to Fluentd,
+the Pod namespace needs to be exposed in the ``KUBERNETES_NAMESPACE`` env var.
+
 
 Development
 ===========

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-1.2.1 (unreleased)
+1.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for logging to Fluentd. [lgraf]
 
 
 1.2.0 (2020-05-04)

--- a/ftw/contentstats/logger.py
+++ b/ftw/contentstats/logger.py
@@ -1,5 +1,7 @@
 from App.config import getConfiguration
 from datetime import datetime
+from fluent.asynchandler import FluentHandler
+from fluent.handler import FluentRecordFormatter
 from ftw.contentstats.stats import ContentStats
 from logging import FileHandler
 from logging import getLogger
@@ -9,6 +11,7 @@ from tzlocal import get_localzone
 from zope.component.hooks import getSite
 import json
 import logging
+import os
 import pytz
 
 
@@ -19,17 +22,46 @@ LOG_TZ = get_localzone()
 
 
 def setup_logger():
-    """Set up logger that writes to the JSON based logfile.
+    """Set up logger that writes to a JSON logfile or a Fluentd instance.
 
     May be invoked multiple times, and must therefore be idempotent.
     """
     if not logger.handlers:
-        path = get_logfile_path()
-        if path is not None:
-            handler = FileHandler(path)
-            logger.addHandler(handler)
-            logger.setLevel(logging.INFO)
-            logger.propagate = False
+        fluent_host = os.environ.get('FLUENT_HOST')
+        fluent_port = int(os.environ.get('FLUENT_PORT', 24224))
+
+        if fluent_host:
+            setup_fluent_handler(fluent_host, fluent_port)
+        else:
+            setup_jsonfile_handler()
+
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+
+    return logger
+
+
+def setup_fluent_handler(fluent_host, fluent_port):
+    """Set up handler that writes to a Fluentd / Fluent Bit instance.
+    """
+    tag = 'contentstats-json.log'
+    ns = os.environ.get('KUBERNETES_NAMESPACE')
+    if ns:
+        tag = '-'.join((ns, tag))
+
+    handler = FluentHandler(tag, fluent_host, fluent_port)
+    handler.setFormatter(FluentRecordFormatter())
+    logger.addHandler(handler)
+    return logger
+
+
+def setup_jsonfile_handler():
+    """Set up handler that writes to the JSON based logfile.
+    """
+    path = get_logfile_path()
+    if path is not None:
+        handler = FileHandler(path)
+        logger.addHandler(handler)
     return logger
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 import os
 
-version = '1.2.1.dev0'
+version = '1.3.0.dev0'
 
 tests_require = [
     'ftw.builder',
@@ -65,6 +65,7 @@ setup(
         'pytz',
         'requests',
         'path.py >= 6.2',
+        'fluent-logger',
     ],
 
     tests_require=tests_require,

--- a/test-plone-4.3.x-ftw-monitor.cfg
+++ b/test-plone-4.3.x-ftw-monitor.cfg
@@ -8,3 +8,7 @@ eggs += ftw.monitor
 [versions]
 # tzlocal dropped python 2 support in version 3.0b1
 tzlocal = < 3
+
+# fluent-logger > 0.9.6 is Python3.5+ only and requires msgpack < 0.10.0
+fluent-logger = < 0.10.0
+msgpack = < 0.10.0

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -8,3 +8,7 @@ package-name = ftw.contentstats
 [versions]
 # tzlocal dropped python 2 support in version 3.0b1
 tzlocal = < 3
+
+# fluent-logger > 0.9.6 is Python3.5+ only and requires msgpack < 0.10.0
+fluent-logger = < 0.10.0
+msgpack = < 0.10.0

--- a/test-plone-5.1.x-ftw-monitor.cfg
+++ b/test-plone-5.1.x-ftw-monitor.cfg
@@ -8,3 +8,7 @@ eggs += ftw.monitor
 [versions]
 # tzlocal dropped python 2 support in version 3.0b1
 tzlocal = < 3
+
+# fluent-logger > 0.9.6 is Python3.5+ only and requires msgpack < 0.10.0
+fluent-logger = < 0.10.0
+msgpack = < 0.10.0

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -8,3 +8,7 @@ package-name = ftw.contentstats
 [versions]
 # tzlocal dropped python 2 support in version 3.0b1
 tzlocal = < 3
+
+# fluent-logger > 0.9.6 is Python3.5+ only and requires msgpack < 0.10.0
+fluent-logger = < 0.10.0
+msgpack = < 0.10.0


### PR DESCRIPTION
This adds support for logging to a Fluentd / Fluent Bit instance instead of a local file.

By setting the environment variable ``FLUENT_HOST``, ftw.contentstats can now be directed to log to that host using the Fluent Forward Protocol.

In order for ftw.contentstats to use a proper tag for events logged to Fluentd, the Pod namespace needs to be exposed in the `KUBERNETES_NAMESPACE` env var (see https://github.com/4teamwork/ogg-k8s-apps/pull/4).

For [CA-5505](https://4teamwork.atlassian.net/browse/CA-5505)