### PR TITLE
Support in docker container

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add Python implementation for calculating disk usage. [buchi]
 
 
 1.3.0 (2023-04-04)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 
 - Add Python implementation for calculating disk usage. [buchi]
 
+- Add option to specify data path for disk usage calculation. [buchi]
+
 
 1.3.0 (2023-04-04)
 ------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,8 @@ Changelog
 
 - Add option to specify data path for disk usage calculation. [buchi]
 
+- Add zopectl command for dumping content stats. [buchi]
+
 
 1.3.0 (2023-04-04)
 ------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,8 @@ Changelog
 
 - Add zopectl command for dumping content stats. [buchi]
 
+- Make filestorage (Data.fs) and blobstorage path for disk usage configurable. [buchi]
+
 
 1.3.0 (2023-04-04)
 ------------------

--- a/ftw/contentstats/command.py
+++ b/ftw/contentstats/command.py
@@ -29,6 +29,16 @@ def dump_content_stats(app, args):
         help='Path to data directory for which to calculate disk usage.',
         default=None,
     )
+    parser.add_argument(
+        '--filestorage-path',
+        help='Path to Data.fs used for filestorage disk usage.',
+        default='var/filestorage/Data.fs',
+    )
+    parser.add_argument(
+        '--blobstorage-path',
+        help='Path to directory used for blobstorage disk usage.',
+        default='var/blobstorage',
+    )
 
     if sys.argv[0] != 'dump_content_stats':
         args = args[2:]
@@ -39,6 +49,8 @@ def dump_content_stats(app, args):
         deployment_path,
         use_du_util=not options.python_du,
         data_path=options.data_path,
+        filestorage_path=options.filestorage_path,
+        blobstorage_path=options.blobstorage_path,
     ).calc_and_dump()
 
     site = setup_site(app, options)

--- a/ftw/contentstats/command.py
+++ b/ftw/contentstats/command.py
@@ -1,0 +1,77 @@
+from ftw.contentstats.disk_usage import DiskUsageCalculator
+from ftw.contentstats.logger import log_stats_to_file
+from zope.component.hooks import setSite
+import App.config
+import argparse
+import os.path
+import sys
+
+
+def get_deployment_path():
+    cfg = App.config._config
+    return os.path.normpath(os.path.join(cfg.clienthome, '..', '..'))
+
+
+def dump_content_stats(app, args):
+    parser = argparse.ArgumentParser(description="Dump content stats.")
+    parser.add_argument(
+        '--site-path', '-s',
+        help='Path to the Plone site.',
+        default=None,
+    )
+    parser.add_argument(
+        '--python-du',
+        help='Use Python implementation for disk usage calculation.',
+        action='store_true',
+    )
+    parser.add_argument(
+        '--data-path', '-d',
+        help='Path to data directory for which to calculate disk usage.',
+        default=None,
+    )
+
+    if sys.argv[0] != 'dump_content_stats':
+        args = args[2:]
+    options = parser.parse_args(args)
+
+    deployment_path = get_deployment_path()
+    DiskUsageCalculator(
+        deployment_path,
+        use_du_util=not options.python_du,
+        data_path=options.data_path,
+    ).calc_and_dump()
+
+    site = setup_site(app, options)
+    if site is None:
+        sys.exit(1)
+
+    log_stats_to_file()
+
+
+def get_site(app, options):
+    if options.site_path:
+        return app.unrestrictedTraverse(options.site_path)
+    else:
+        sites = []
+        for item in app.values():
+            if item.meta_type == 'Plone Site':
+                sites.append(item)
+
+        if len(sites) == 1:
+            return sites[0]
+        elif len(sites) > 1:
+            print('ERROR: Multiple Plone sites found. Use -s to specify site.')
+        else:
+            print('ERROR: No Plone site found.')
+
+
+def setup_site(app, options):
+    # Delay import of the Testing module
+    # Importing it before the database is opened, will result in opening a
+    # DemoStorage database instead of the one from the config file.
+    from Testing.makerequest import makerequest  # noqa
+    app = makerequest(app)
+    site = get_site(app, options)
+    if site is not None:
+        setSite(site)
+    return site

--- a/ftw/contentstats/console.py
+++ b/ftw/contentstats/console.py
@@ -28,6 +28,11 @@ def parse_args():
         help='Use Python implementation for disk usage calculation.',
         action='store_true',
     )
+    parser.add_argument(
+        '--data-path', '-d',
+        help='Path to data directory for which to calculate disk usage.',
+        default=None,
+    )
 
     args = parser.parse_args()
     return args
@@ -61,7 +66,10 @@ def dump_stats_cmd():
     # Calculate disk usage stats and dump them to var/log/disk-usage.json
     deployment_path = get_buildout_path()
     DiskUsageCalculator(
-        deployment_path, use_du_util=not args.python_du).calc_and_dump()
+        deployment_path,
+        use_du_util=not args.python_du,
+        data_path=args.data_path,
+    ).calc_and_dump()
 
     zope_url = get_zope_url()
     plone_url = ''.join((zope_url, args.site_id))

--- a/ftw/contentstats/console.py
+++ b/ftw/contentstats/console.py
@@ -33,6 +33,16 @@ def parse_args():
         help='Path to data directory for which to calculate disk usage.',
         default=None,
     )
+    parser.add_argument(
+        '--filestorage-path',
+        help='Path to Data.fs used for filestorage disk usage.',
+        default='var/filestorage/Data.fs',
+    )
+    parser.add_argument(
+        '--blobstorage-path',
+        help='Path to directory used for blobstorage disk usage.',
+        default='var/blobstorage',
+    )
 
     args = parser.parse_args()
     return args
@@ -69,6 +79,8 @@ def dump_stats_cmd():
         deployment_path,
         use_du_util=not args.python_du,
         data_path=args.data_path,
+        filestorage_path=options.filestorage_path,
+        blobstorage_path=options.blobstorage_path,
     ).calc_and_dump()
 
     zope_url = get_zope_url()

--- a/ftw/contentstats/console.py
+++ b/ftw/contentstats/console.py
@@ -23,6 +23,11 @@ def parse_args():
         '--site-id', '-s',
         help='Path to the Plone site.',
         required=True)
+    parser.add_argument(
+        '--python-du',
+        help='Use Python implementation for disk usage calculation.',
+        action='store_true',
+    )
 
     args = parser.parse_args()
     return args
@@ -55,7 +60,8 @@ def dump_stats_cmd():
 
     # Calculate disk usage stats and dump them to var/log/disk-usage.json
     deployment_path = get_buildout_path()
-    DiskUsageCalculator(deployment_path).calc_and_dump()
+    DiskUsageCalculator(
+        deployment_path, use_du_util=not args.python_du).calc_and_dump()
 
     zope_url = get_zope_url()
     plone_url = ''.join((zope_url, args.site_id))

--- a/ftw/contentstats/disk_usage.py
+++ b/ftw/contentstats/disk_usage.py
@@ -20,16 +20,24 @@ except ImportError:
     from os import walk
 
 
-
 class DiskUsageCalculator(object):
 
     du_stats_path = 'var/log/disk-usage.json'
 
-    def __init__(self, deployment_path, use_du_util=True, data_path=None):
+    def __init__(
+        self,
+        deployment_path,
+        use_du_util=True,
+        data_path=None,
+        filestorage_path='var/filestorage/Data.fs',
+        blobstorage_path='var/blobstorage',
+    ):
         self.deployment_path = deployment_path
         self.du_executable = None
         self.use_du_util = use_du_util
         self.data_path = data_path or deployment_path
+        self.filestorage_path = filestorage_path
+        self.blobstorage_path = blobstorage_path
 
         # This facilitates testing without actually running `du`
         self.du_outputs = {}
@@ -121,6 +129,8 @@ class DiskUsageCalculator(object):
         du_stats['updated'] = datetime.now().isoformat()
         du_stats['total'] = disk_usage_total
         du_stats['subtrees'] = disk_usage_subtrees
+        du_stats['filestorage'] = disk_usage_subtrees.get(self.filestorage_path, 0)
+        du_stats['blobstorage'] = disk_usage_subtrees.get(self.blobstorage_path, 0)
         return du_stats
 
     def calc_du_total(self):

--- a/ftw/contentstats/providers/disk_usage.py
+++ b/ftw/contentstats/providers/disk_usage.py
@@ -41,13 +41,10 @@ class DiskUsageProvider(object):
             log.warn('Unable to read disk usage stats from %r' % path)
             return {}
 
-        # XXX: The paths to filestorage and blobstorage could eventually be
-        # determined dynamically (ZODB APIs should be able to tell us).
-
         stats = {}
         stats['total'] = disk_usage['total']
-        stats['filestorage'] = disk_usage['subtrees']['var/filestorage/Data.fs']
-        stats['blobstorage'] = disk_usage['subtrees']['var/blobstorage']
+        stats['filestorage'] = disk_usage['filestorage']
+        stats['blobstorage'] = disk_usage['blobstorage']
         return stats
 
     def get_display_names(self):

--- a/ftw/contentstats/tests/assets/disk-usage.json
+++ b/ftw/contentstats/tests/assets/disk-usage.json
@@ -1,5 +1,7 @@
 {
+    "blobstorage": 45,
     "deployment": "/path/to/deployment",
+    "filestorage": 20,
     "updated": "2018-12-30T12:45:00",
     "subtrees": {
         "bin": 10,

--- a/ftw/contentstats/tests/test_disk_usage.py
+++ b/ftw/contentstats/tests/test_disk_usage.py
@@ -118,7 +118,9 @@ class TestDiskUsageCalculator(TestCase):
             du_stats = calculator.calc_du_stats()
 
         # Should reduce subtree depth to 2 levels, except for var/filestorage/*
-        self.assertEqual({'deployment': '/path/to/deployment',
+        self.assertEqual({'blobstorage': 45,
+                          'deployment': '/path/to/deployment',
+                          'filestorage': 20,
                           'updated': FROZEN_NOW.isoformat(),
                           'total': 1024,
                           'subtrees': {'bin': 10,

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,9 @@ setup(
     [z3c.autoinclude.plugin]
     target = plone
 
+    [zopectl.command]
+    dump_content_stats = ftw.contentstats.command:dump_content_stats
+
     [console_scripts]
     dump-content-stats = ftw.contentstats.console:dump_stats_cmd
     """,

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ tests_require = [
 
 extras_require = {
     'tests': tests_require,
+    'scandir': ['scandir']
 }
 
 


### PR DESCRIPTION
- Add Python implementation for calculating disk usage:
  The various `du` implementations (GNU, BSD) differ in terms of functionality and command line parameters and are hard to support on every platform (e.g. Alpine Linux). The Python implementation should work everywhere, but might be slower. The Python implementation can be enabled with the `--python-du` command line option.
- Add option to specify data path for disk usage calculation:
  In a Docker container data is usually located in a volume that can be hard to determine automatically. The `--data-path` option allows to specify the location manually.
- Make filestorage (Data.fs) and blobstorage path for disk usage configurable.
  The directory layout may vary as well. By providing the filestorage and blobstorage paths, it's possible to support different layouts.
- Add zopectl command for dumping content stats:
  Unlike the console command, the zopectl command doesn't require a running instance, which is hard to find when run inside a container.

If installed, the `scandir` package will be used for walking the filesystem when calculation disk usage, which should be faster than Python's implementation.
